### PR TITLE
Improving index.html 

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -71,7 +71,7 @@ The following fields are required in each entry JSON file. Ensure that all entri
   ```
 
   - **`derivation`:**
-  - Provide a formal derivation of the result, including all steps and equations in AsciiMath format. If the equation cannot be derived from other first principles, the 
+  - Provide a formal derivation of the result, including all steps and equations in AsciiMath format. If the equation cannot be derived from other first principles, the
   - Each step should contain the `id` and `equation` fields.
   - The `step` field should be an integer, following the sequential order of the reasoning process.
   - The `equation` field should contain the equation in AsciiMath format, without any additional text such as explanations or assumptions.
@@ -198,8 +198,6 @@ The following fields are required in each entry JSON file. Ensure that all entri
 }
 ]
 ```
-
-- **`dataset_version`:** Must follow the format MAJOR.MINOR.PATCH (e.g., "1.0.0"). This should match the global version in `manifest.json`.
 
 - **`created_ by`:** Full name or ORCID of author of the entry.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# THEORIA dataset, a curated, high quality dataset of Theoretical Physics equations
+# TheorIA dataset, a curated, high quality dataset of Theoretical Physics equations
 
-THEORIA stands for Trusted Human-curated Equations Open-licensed Reproducible Itemized Archive.
+TheorIA stands for Theoretical Physics Intelligent Anthology
 
-> **🚀 Jump in!** We've kicked off THEORIA with a handful of killer entries, and we need your help to grow it. If you're a theoretical‑physics buff—researcher, educator, or enthusiast—now's the time to contribute your favorite equations, crisp derivations, and clear explanations.
+> **🚀 Jump in!** We've kicked off THEORIA with a handful of entries, and we need your help to grow it. If you're into physics—researcher, educator, or enthusiast—now's the time to contribute your favorite equations, crisp derivations, and clear explanations.
 
-**[Browse the THEORIA Dataset Online](https://theoria-dataset.github.io/theoria-dataset/)** - View and explore the equations and derivations through our interactive web interface.
+**[Browse the TheorIA Dataset Online](https://theoria-dataset.github.io/theoria-dataset/)** - View and explore the equations and derivations through our interactive web interface.
 
-## Why THEORIA?
+## Why TheorIA?
 
 There is a [lack of curated datasets](https://manuelsh.github.io/blog/2025/datasets-for-advancing-Theoretical-Physics/) with all important equations and derivations of theoretical physics to train better machine learning models, beyond raw text in papers and books.
 
@@ -16,7 +16,7 @@ We have an open license and encourage contributions from researchers, educators,
 
 ## What's inside?
 
-Each entry in THEORIA represents a theoretical physics result – for example, the Lorentz transformations.
+Each entry in TheorIA represents a theoretical physics result – for example, the Lorentz transformations.
 
 - **High quality**: Each entry is crafted and carefully reviewed by someone with a background in physics. Contributor name or ORCID is baked into the metadata.
 
@@ -71,7 +71,7 @@ Feed `dataset.json` (or per‑entry files) straight into your training pipeline.
 Licensed under [CC-BY 4.0 License](https://creativecommons.org/licenses/by/4.0/legalcode.en). If you use it please cite it as:
 
 ```
-THEORIA Dataset, 2025, v0.0.1. Available at: https://github.com/theoria-dataset/theoria-dataset
+TheorIA Dataset, 2025, v0.0.1. Available at: https://github.com/theoria-dataset/theoria-dataset
 ```
 
 ## Contact

--- a/docs/entries.html
+++ b/docs/entries.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en" class="text-justify latex-dark">
+  <head>
+    <meta charset="utf-8" />
+    <title>TheorIA — Dataset Entries</title>
+    <!-- LaTeX.css dark theme -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/latex.css@1.8.0/style.min.css"
+    />
+    <!-- MathJax for AsciiMath -->
+    <script>
+      window.MathJax = {
+        loader: { load: ["input/asciimath", "output/chtml"] },
+        asciimath: { delimiters: [["`", "`"]] },
+      };
+    </script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/startup.js"
+      async
+    ></script>
+    <!-- highlight.js -->
+    <link
+      id="hl-theme"
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/github-dark.min.css"
+    />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"
+      defer
+    ></script>
+    <!-- External CSS -->
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <button id="themeToggle" aria-label="Toggle theme">☀︎</button>
+    <div id="entryView" class="entry-view">
+      <button onclick="window.location.href='index.html'" class="cta-button">
+        ← Back to Home
+      </button>
+      <div class="controls">
+        <label for="entrySelector"><strong>Select Entry:</strong></label>
+        <select id="entrySelector">
+          <option value="">— choose one —</option>
+        </select>
+      </div>
+      <h1 id="title" style="display: none">Select an entry</h1>
+      <p id="explanation"></p>
+      <section id="equations" style="display: none">
+        <h2>Main result</h2>
+        <div id="equations-content"></div>
+      </section>
+      <section id="definitions" style="display: none">
+        <table>
+          <thead>
+            <tr>
+              <th>Symbol</th>
+              <th>Definition</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
+      <section id="assumptions" style="display: none">
+        <h2>Result assumptions</h2>
+        <ul></ul>
+      </section>
+      <section id="derivation" style="display: none">
+        <h2>Derivation</h2>
+        <section id="derivationAssumptions" style="display: none">
+          <h3>Assumptions</h3>
+          <ul></ul>
+        </section>
+        <section id="derivationSteps" style="display: none">
+          <h3>Derivation steps</h3>
+          <ol></ol>
+        </section>
+      </section>
+      <section id="programmaticVerification" style="display: none">
+        <h2>Programmatic Verification</h2>
+        <p><strong>Language:</strong> <span id="pv-language"></span></p>
+        <p><strong>Library:</strong> <span id="pv-library"></span></p>
+        <pre><code id="pv-code" class="language-python"></code></pre>
+      </section>
+      <section id="references" style="display: none">
+        <h2>References</h2>
+        <ul></ul>
+      </section>
+      <section class="metadata" style="display: none">
+        <small>
+          <ul>
+            <li>
+              <strong>Created By:</strong> <span id="meta-created"></span>
+            </li>
+            <li>
+              <strong>Review Status:</strong> <span id="meta-status"></span>
+            </li>
+          </ul>
+        </small>
+      </section>
+    </div>
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/docs/entries.html
+++ b/docs/entries.html
@@ -87,16 +87,33 @@
         <ul></ul>
       </section>
       <section class="metadata" style="display: none">
-        <small>
-          <ul>
-            <li>
-              <strong>Created By:</strong> <span id="meta-created"></span>
-            </li>
-            <li>
-              <strong>Review Status:</strong> <span id="meta-status"></span>
-            </li>
-          </ul>
-        </small>
+        <footer class="entry-footer">
+          <div class="metadata-grid">
+            <div class="metadata-item">
+              <strong>Entry created by:</strong>
+              <span id="meta-created"></span>
+            </div>
+            <div class="metadata-item">
+              <strong>Domain:</strong>
+              <span id="meta-domain"></span>
+            </div>
+            <div class="metadata-item">
+              <strong>Review Status:</strong>
+              <span id="meta-status"></span>
+            </div>
+            <div class="metadata-item">
+              <strong>Open license:</strong>
+              <span
+                ><a
+                  href="https://creativecommons.org/licenses/by/4.0/deed.en"
+                  target="_blank"
+                  rel="noopener"
+                  >CC-BY 4.0</a
+                ></span
+              >
+            </div>
+          </div>
+        </footer>
       </section>
     </div>
     <script src="script.js" defer></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,208 +1,209 @@
 <!DOCTYPE html>
 <html lang="en" class="text-justify latex-dark">
-
-<head>
+  <head>
     <meta charset="utf-8" />
-    <title>THEORIA — Theoretical Physics Dataset</title>
+    <title>TheorIA — Theoretical Physics Dataset</title>
 
     <!-- LaTeX.css dark theme -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/latex.css@1.8.0/style.min.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/latex.css@1.8.0/style.min.css"
+    />
 
     <!-- MathJax for AsciiMath -->
     <script>
-        window.MathJax = {
-            loader: { load: ["input/asciimath", "output/chtml"] },
-            asciimath: { delimiters: [["`", "`"]] },
-        };
+      window.MathJax = {
+        loader: { load: ["input/asciimath", "output/chtml"] },
+        asciimath: { delimiters: [["`", "`"]] },
+      };
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/startup.js" async></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/startup.js"
+      async
+    ></script>
 
     <!-- highlight.js -->
-    <link id="hl-theme" rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/github-dark.min.css" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js" defer></script>
+    <link
+      id="hl-theme"
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/github-dark.min.css"
+    />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"
+      defer
+    ></script>
 
     <!-- External CSS -->
     <link rel="stylesheet" href="styles.css" />
-</head>
+  </head>
 
-<body>
+  <body>
     <button id="themeToggle" aria-label="Toggle theme">☀︎</button>
 
     <!-- Home View -->
     <div id="homeView" class="home-view">
-        <div class="hero">
-            <h1>THEORIA Dataset</h1>
-            <p>A curated, high-quality dataset of Theoretical Physics equations and derivations.</p>
+      <div class="hero">
+        <h1>TheorIA Dataset</h1>
+        <p>
+          A curated, high-quality dataset of Theoretical Physics equations and
+          derivations.
+        </p>
 
-            <div class="entry-selector-container">
-                <select id="homeEntrySelector">
-                    <option value="">View entries</option>
-                </select>
-            </div>
-
-            <a href="https://github.com/theoria-dataset/theoria-dataset" class="cta-button">GitHub Repository</a>
+        <div class="entry-selector-container">
+          <a href="entries.html" class="cta-button">View entries</a>
         </div>
 
-        <section>
-            <h2>Why THEORIA?</h2>
-            <p>There is a <a
-                    href="https://manuelsh.github.io/blog/2025/datasets-for-advancing-Theoretical-Physics/">lack of
-                    curated datasets</a> with all important equations and derivations of theoretical physics to train
-                better machine learning models, beyond raw text in papers and books.</p>
-            <p>THEORIA bridges that gap; it is the first dataset to provide a high-quality collection of theoretical
-                physics equations, their derivations and explanations in a structured format.</p>
-            <blockquote>
-                <p><strong>🚀 Jump in!</strong> We've kicked off THEORIA with a handful of killer entries, and we need
-                    your help to grow it. If you're a theoretical‑physics buff—researcher, educator, or enthusiast—now's
-                    the time to contribute your favorite equations, crisp derivations, and clear explanations.</p>
-            </blockquote>
-        </section>
+        <a
+          href="https://github.com/theoria-dataset/theoria-dataset"
+          class="cta-button"
+          >GitHub Repository</a
+        >
+      </div>
 
-        <section>
-            <h2>What's Inside?</h2>
-            <div class="feature-grid">
-                <div class="feature-card">
-                    <h3>High Quality</h3>
-                    <p>Each entry is crafted and carefully reviewed by someone with a background in physics. Contributor
-                        name or ORCID is baked into the metadata.</p>
-                </div>
-                <div class="feature-card">
-                    <h3>Formal Derivations</h3>
-                    <p>AsciiMath step by step, annotated for easier understanding and programmatic formalization to
-                        guarantee correctness.</p>
-                </div>
-                <div class="feature-card">
-                    <h3>Self-Contained JSON</h3>
-                    <p>One entry per file under <code class="inline">entries/</code> folder, so you can fork, version,
-                        and collaborate without conflicts.</p>
-                </div>
-                <div class="feature-card">
-                    <h3>Domain Tags</h3>
-                    <p>ArXiv‑style categories (e.g., gr-qc, hep-th) for easy filtering.</p>
-                </div>
-                <div class="feature-card">
-                    <h3>Global Manifest</h3>
-                    <p><code class="inline">manifest.json</code> tracks versions, file list, covered domains, and
-                        updates.</p>
-                </div>
-                <div class="feature-card">
-                    <h3>Open License</h3>
-                    <p><code class="inline">CC‑BY 4.0</code>—use it, remix it, teach with it.</p>
-                </div>
-            </div>
-        </section>
+      <section>
+        <h2>Why TheorIA?</h2>
+        <p>
+          There is a
+          <a
+            href="https://manuelsh.github.io/blog/2025/datasets-for-advancing-Theoretical-Physics/"
+            >lack of curated datasets</a
+          >
+          with all important equations and derivations of theoretical physics to
+          train better machine learning models, beyond raw text in papers and
+          books.
+        </p>
+        <p>
+          TheorIA bridges that gap; it is the first dataset to provide a
+          high-quality collection of theoretical physics equations, their
+          derivations and explanations in a structured format.
+        </p>
+        <blockquote>
+          <p>
+            <strong>🚀 Jump in!</strong> We've kicked off TheorIA with a handful
+            of killer entries, and we need your help to grow it. If you're a
+            theoretical‑physics buff—researcher, educator, or enthusiast—now's
+            the time to contribute your favorite equations, crisp derivations,
+            and clear explanations.
+          </p>
+        </blockquote>
+      </section>
 
-        <section>
-            <h2>How to Contribute</h2>
-            <p>We are <em>tiny</em> right now, every new entry counts! To contribute:</p>
-
-            <div class="feature-card">
-                <h3><span class="step-number">1</span>Fork and Clone</h3>
-                <p>Fork the repository on GitHub and clone it to your local machine.</p>
-            </div>
-
-            <div class="feature-card">
-                <h3><span class="step-number">2</span>Create a JSON Entry</h3>
-                <p>Create a JSON file in the <code class="inline">entries/</code> folder following the instructions in
-                    the <code class="inline">CONTRIBUTING.md</code> file and the schema in <code
-                        class="inline">schemas/entry.schema.json</code>.</p>
-            </div>
-
-            <div class="feature-card">
-                <h3><span class="step-number">3</span>Submit a Pull Request</h3>
-                <p>CI will automatically validate your JSON against the schema. If it passes, we will review and merge
-                    it.</p>
-            </div>
-        </section>
-
-        <section>
-            <h2>Using THEORIA for Machine Learning</h2>
-            <p>You can either use the individual JSON files or automatically generate a single merged file using a
-                script (e.g., with <code class="inline">jq</code>):</p>
-            <pre><code>jq -s '.' entries/*.json > dataset.json</code></pre>
-            <p>Feed <code class="inline">dataset.json</code> (or per‑entry files) straight into your training pipeline.
+      <section>
+        <h2>What's Inside?</h2>
+        <div class="feature-grid">
+          <div class="feature-card">
+            <h3>High Quality</h3>
+            <p>
+              Each entry is crafted and carefully reviewed by someone with a
+              background in physics. Contributor name or ORCID is baked into the
+              metadata.
             </p>
-        </section>
-
-        <section>
-            <h2>License & Citation</h2>
-            <p>Licensed under <a href="https://creativecommons.org/licenses/by/4.0/legalcode.en">CC-BY 4.0 License</a>.
-                If you use it please cite it as:</p>
-            <pre><code>THEORIA Dataset, 2025, v0.0.1. Available at: https://github.com/theoria-dataset/theoria-dataset</code></pre>
-        </section>
-
-        <section>
-            <h2>Contact</h2>
-            <p>Issues, questions, or exciting physics ideas? Drop an issue on GitHub—and let's build this thing
-                together.</p>
-        </section>
-    </div>
-
-    <!-- Entry View -->
-    <div id="entryView" class="entry-view hidden">
-        <button id="viewToggleBtn" class="cta-button">← Back to Home</button>
-
-        <h1 id="title">Select an entry</h1>
-        <div class="controls">
-            <label for="entrySelector"><strong>Select Entry:</strong></label>
-            <select id="entrySelector">
-                <option value="">— choose one —</option>
-            </select>
+          </div>
+          <div class="feature-card">
+            <h3>Formal Derivations</h3>
+            <p>
+              AsciiMath step by step, annotated for easier understanding and
+              programmatic formalization to guarantee correctness.
+            </p>
+          </div>
+          <div class="feature-card">
+            <h3>Self-Contained JSON</h3>
+            <p>
+              One entry per file under
+              <code class="inline">entries/</code> folder, so you can fork,
+              version, and collaborate without conflicts.
+            </p>
+          </div>
+          <div class="feature-card">
+            <h3>Domain Tags</h3>
+            <p>
+              ArXiv‑style categories (e.g., gr-qc, hep-th) for easy filtering.
+            </p>
+          </div>
+          <div class="feature-card">
+            <h3>Global Manifest</h3>
+            <p>
+              <code class="inline">manifest.json</code> tracks versions, file
+              list, covered domains, and updates.
+            </p>
+          </div>
+          <div class="feature-card">
+            <h3>Open License</h3>
+            <p>
+              <code class="inline">CC‑BY 4.0</code>—use it, remix it, teach with
+              it.
+            </p>
+          </div>
         </div>
-        <p id="explanation"></p>
+      </section>
 
-        <section id="equations">
-            <h2>Equations</h2>
-            <ul></ul>
-        </section>
-        <section id="assumptions">
-            <h2>Equations Assumptions</h2>
-            <ul></ul>
-        </section>
-        <section id="derivationAssumptions">
-            <h2>Derivation Assumptions</h2>
-            <ul></ul>
-        </section>
-        <section id="definitions">
-            <h2>Definitions</h2>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Symbol</th>
-                        <th>Definition</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
-        </section>
-        <section id="derivation">
-            <h2>Derivation</h2>
-            <ol></ol>
-        </section>
-        <section id="programmaticVerification">
-            <h2>Programmatic Verification</h2>
-            <p><strong>Language:</strong> <span id="pv-language"></span></p>
-            <p><strong>Library:</strong> <span id="pv-library"></span></p>
-            <pre><code id="pv-code" class="language-python"></code></pre>
-        </section>
-        <section id="references">
-            <h2>References</h2>
-            <ul></ul>
-        </section>
-        <section class="metadata">
-            <ul>
-                <li><strong>Domain:</strong> <span id="meta-domain"></span></li>
-                <li>
-                    <strong>Dataset Version:</strong> <span id="meta-dataset"></span>
-                </li>
-                <li><strong>Created By:</strong> <span id="meta-created"></span></li>
-                <li><strong>Review Status:</strong> <span id="meta-status"></span></li>
-            </ul>
-        </section>
+      <section>
+        <h2>How to Contribute</h2>
+        <p>
+          We are <em>tiny</em> right now, every new entry counts! To contribute:
+        </p>
+
+        <div class="feature-card">
+          <h3><span class="step-number">1</span>Fork and Clone</h3>
+          <p>
+            Fork the repository on GitHub and clone it to your local machine.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <h3><span class="step-number">2</span>Create a JSON Entry</h3>
+          <p>
+            Create a JSON file in the
+            <code class="inline">entries/</code> folder following the
+            instructions in the <code class="inline">CONTRIBUTING.md</code> file
+            and the schema in
+            <code class="inline">schemas/entry.schema.json</code>.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <h3><span class="step-number">3</span>Submit a Pull Request</h3>
+          <p>
+            CI will automatically validate your JSON against the schema. If it
+            passes, we will review and merge it.
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Using TheorIA for Machine Learning</h2>
+        <p>
+          You can either use the individual JSON files or automatically generate
+          a single merged file using a script (e.g., with
+          <code class="inline">jq</code>):
+        </p>
+        <pre><code>jq -s '.' entries/*.json > dataset.json</code></pre>
+        <p>
+          Feed <code class="inline">dataset.json</code> (or per‑entry files)
+          straight into your training pipeline.
+        </p>
+      </section>
+
+      <section>
+        <h2>License & Citation</h2>
+        <p>
+          Licensed under
+          <a href="https://creativecommons.org/licenses/by/4.0/legalcode.en"
+            >CC-BY 4.0 License</a
+          >. If you use it please cite it as:
+        </p>
+        <pre><code>THEORIA Dataset, 2025, v0.0.1. Available at: https://github.com/theoria-dataset/theoria-dataset</code></pre>
+      </section>
+
+      <section>
+        <h2>Contact</h2>
+        <p>
+          Issues, questions, or exciting physics ideas? Drop an issue on
+          GitHub—and let's build this thing together.
+        </p>
+      </section>
     </div>
 
     <script src="script.js" defer></script>
-</body>
-
+  </body>
 </html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -8,15 +8,12 @@ const homeView = $("homeView");
 const entryView = $("entryView");
 const viewToggleBtn = $("viewToggleBtn");
 
-function showEntryView() {
-  homeView.classList.add("hidden");
-  entryView.classList.remove("hidden");
+if (viewToggleBtn) {
+  viewToggleBtn.addEventListener("click", () => {
+    entryView.classList.add("hidden");
+    homeView.classList.remove("hidden");
+  });
 }
-
-viewToggleBtn.addEventListener("click", () => {
-  entryView.classList.add("hidden");
-  homeView.classList.remove("hidden");
-});
 
 // Dark mode toggle using latex-dark class
 const btn = $("themeToggle");
@@ -43,48 +40,64 @@ const baseUrl = isGitHubPages
   ? "https://raw.githubusercontent.com/theoria-dataset/theoria-dataset/main"
   : "..";
 
-// Populate entries for both selectors
+// Populate entries for the selector in entries.html only
 fetch("index.json")
   .then((r) => r.json())
   .then((list) => {
     list.forEach((fn) => {
-      // For the main entry view
       const o1 = document.createElement("option");
       o1.value = fn;
       o1.textContent = fn.replace(".json", "");
       $("entrySelector").appendChild(o1);
-
-      // For the home page entry selector
-      const o2 = document.createElement("option");
-      o2.value = fn;
-      o2.textContent = fn.replace(".json", "");
-      $("homeEntrySelector").appendChild(o2);
     });
   });
-
-// Handler for entry selector on home page
-$("homeEntrySelector").addEventListener("change", () => {
-  const file = $("homeEntrySelector").value;
-  if (!file) return; // If "View entries" is selected
-
-  // Set the same value to the other selector
-  $("entrySelector").value = file;
-
-  // Show entry view
-  showEntryView();
-
-  // Load the entry using the appropriate base URL
-  fetch(`${baseUrl}/entries/${file}`)
-    .then((r) => r.json())
-    .then(render)
-    .catch(console.error);
-});
 
 // Handler for entry selector in entry view
 $("entrySelector").addEventListener("change", () => {
   const file = $("entrySelector").value;
-  if (!file) return;
-
+  const sections = [
+    "equations",
+    "assumptions",
+    "derivationAssumptions",
+    "definitions",
+    "derivation",
+    "programmaticVerification",
+    "references",
+    "meta-domain",
+    "meta-dataset",
+    "meta-created",
+    "meta-status",
+  ];
+  // Also hide all section titles (h2, h1, etc) when no entry is selected
+  if (!file) {
+    $("title").style.display = "none";
+    $("explanation").textContent = "Select any entry to show it.";
+    // Hide all sections and their headings
+    sections.forEach((id) => {
+      const el = $(id) || qs(`.${id}`);
+      if (el) el.style.display = "none";
+      // Hide section headings (h2) inside each section
+      if (el && el.querySelector && el.querySelector("h2")) {
+        el.querySelector("h2").style.display = "none";
+      }
+    });
+    // Hide all h2s globally (for metadata section)
+    document
+      .querySelectorAll("#entryView h2")
+      .forEach((h) => (h.style.display = "none"));
+    return;
+  }
+  $("title").style.display = "";
+  sections.forEach((id) => {
+    const el = $(id) || qs(`.${id}`);
+    if (el) el.style.display = "";
+    if (el && el.querySelector && el.querySelector("h2")) {
+      el.querySelector("h2").style.display = "";
+    }
+  });
+  document
+    .querySelectorAll("#entryView h2")
+    .forEach((h) => (h.style.display = ""));
   // Load the entry using the appropriate base URL
   fetch(`${baseUrl}/entries/${file}`)
     .then((r) => r.json())
@@ -94,19 +107,74 @@ $("entrySelector").addEventListener("change", () => {
 
 // Render function
 function render(data) {
+  $("title").style.display = "";
   $("title").textContent = data.result_name;
   $("explanation").innerHTML = data.explanation;
-  renderList(
-    "#equations ul",
-    data.result_equations,
-    (eq) => "`" + eq.equation + "`"
-  );
+  // Show all sections and their headings
+  [
+    "equations",
+    "assumptions",
+    "derivationAssumptions",
+    "definitions",
+    "derivation",
+    "programmaticVerification",
+    "references",
+    "meta-domain",
+    "meta-dataset",
+    "meta-created",
+    "meta-status",
+  ].forEach((id) => {
+    const el = $(id) || qs(`.${id}`);
+    if (el) el.style.display = "";
+    if (el && el.querySelector && el.querySelector("h2")) {
+      el.querySelector("h2").style.display = "";
+    }
+  });
+  document
+    .querySelectorAll("#entryView h2")
+    .forEach((h) => (h.style.display = ""));
+  // Render equations as <p> blocks, not as a list
+  const eqDiv = $("equations-content");
+  eqDiv.innerHTML = (data.result_equations || [])
+    .map((eq) => `<p>\`${eq.equation}\`</p>`)
+    .join("");
+  MathJax.typesetPromise([eqDiv]);
   renderList("#assumptions ul", data.equations_assumptions, (a) => a.text);
+  MathJax.typesetPromise([qs("#assumptions")]);
+
+  // Ensure derivation sections are visible
+  $("derivation").style.display = "";
+  $("derivationAssumptions").style.display = "";
+  $("derivationSteps").style.display = "";
+
+  // Render derivation assumptions
   renderList(
     "#derivationAssumptions ul",
     data.derivation_assumptions,
     (a) => a.text
   );
+  MathJax.typesetPromise([qs("#derivationAssumptions")]);
+
+  // Render derivation steps into #derivationSteps ol
+  const ol = qs("#derivationSteps ol");
+  ol.innerHTML = "";
+  const explanationMap = {};
+  (data.derivation_explanation || []).forEach(
+    (e) => (explanationMap[e.step] = e.text)
+  );
+  (data.derivation || []).forEach((step) => {
+    let html = "";
+    if (explanationMap[step.step]) {
+      html += `<div class='step-expl'>${explanationMap[step.step]}</div>`;
+    }
+    if (step.equation) {
+      html += `<div class='step-eq'>\`${step.equation}\`</div>`;
+    } else if (step.text) {
+      html += `<div class='step-text'>${step.text}</div>`;
+    }
+    ol.insertAdjacentHTML("beforeend", `<li>${html}</li>`);
+  });
+  MathJax.typesetPromise([qs("#derivationSteps")]);
 
   const tbody = qs("#definitions tbody");
   tbody.innerHTML = "";
@@ -116,36 +184,30 @@ function render(data) {
       `<tr><td>${d.symbol}</td><td>${d.definition}</td></tr>`
     );
   });
+  MathJax.typesetPromise([qs("#definitions")]);
 
-  const ol = qs("#derivation ol");
-  ol.innerHTML = "";
-  const map = {};
-  (data.derivation_explanation || []).forEach((e) => (map[e.step] = e.text));
-  data.derivation.forEach((step) => {
-    const expl = map[step.step]
-      ? `<p class='step-expl'>${map[step.step]}</p>`
-      : "";
-    const body = step.equation
-      ? `<p class='step-eq'>\`${step.equation}\`</p>`
-      : `<p>${step.text || ""}</p>`;
-    ol.insertAdjacentHTML("beforeend", `<li>${expl}${body}</li>`);
-  });
-
+  // Programmatic verification
   $("pv-language").textContent = data.programmatic_verification.language;
   $("pv-library").textContent = data.programmatic_verification.library;
   const codeEl = $("pv-code");
   codeEl.textContent = data.programmatic_verification.code.join("\n");
   hljs.highlightElement(codeEl);
+  MathJax.typesetPromise([qs("#programmaticVerification")]);
 
   renderList("#references ul", data.references, (r) => r.citation);
+  MathJax.typesetPromise([qs("#references")]);
 
   $("meta-domain").textContent = data.domain;
   $("meta-dataset").textContent = data.dataset_version;
   $("meta-created").textContent = data.created_by;
   $("meta-status").textContent = data.review_status;
 
-  // Typeset math
-  MathJax.typesetPromise();
+  // Ensure metadata section is visible
+  const metaSection = qs(".metadata");
+  if (metaSection) metaSection.style.display = "";
+
+  // Typeset math for the whole entry view as a fallback
+  MathJax.typesetPromise([qs("#entryView")]);
 }
 
 function renderList(sel, arr, fn) {

--- a/docs/script.js
+++ b/docs/script.js
@@ -41,69 +41,71 @@ const baseUrl = isGitHubPages
   : "..";
 
 // Populate entries for the selector in entries.html only
-fetch("index.json")
-  .then((r) => r.json())
-  .then((list) => {
-    list.forEach((fn) => {
-      const o1 = document.createElement("option");
-      o1.value = fn;
-      o1.textContent = fn.replace(".json", "");
-      $("entrySelector").appendChild(o1);
+if (window.location.pathname.includes("entries.html")) {
+  fetch("index.json")
+    .then((r) => r.json())
+    .then((list) => {
+      list.forEach((fn) => {
+        const o1 = document.createElement("option");
+        o1.value = fn;
+        o1.textContent = fn.replace(".json", "");
+        $("entrySelector").appendChild(o1);
+      });
     });
-  });
 
-// Handler for entry selector in entry view
-$("entrySelector").addEventListener("change", () => {
-  const file = $("entrySelector").value;
-  const sections = [
-    "equations",
-    "assumptions",
-    "derivationAssumptions",
-    "definitions",
-    "derivation",
-    "programmaticVerification",
-    "references",
-    "meta-domain",
-    "meta-dataset",
-    "meta-created",
-    "meta-status",
-  ];
-  // Also hide all section titles (h2, h1, etc) when no entry is selected
-  if (!file) {
-    $("title").style.display = "none";
-    $("explanation").textContent = "Select any entry to show it.";
-    // Hide all sections and their headings
+  // Handler for entry selector in entry view
+  $("entrySelector").addEventListener("change", () => {
+    const file = $("entrySelector").value;
+    const sections = [
+      "equations",
+      "assumptions",
+      "derivationAssumptions",
+      "definitions",
+      "derivation",
+      "programmaticVerification",
+      "references",
+      "meta-domain",
+      "meta-created",
+      "meta-status",
+      "metadata",
+    ];
+    // Also hide all section titles (h2, h1, etc) when no entry is selected
+    if (!file) {
+      $("title").style.display = "none";
+      $("explanation").textContent = "Select any entry to show it.";
+      // Hide all sections and their headings
+      sections.forEach((id) => {
+        const el = $(id) || qs(`.${id}`);
+        if (el) el.style.display = "none";
+        // Hide section headings (h2) inside each section
+        if (el && el.querySelector && el.querySelector("h2")) {
+          el.querySelector("h2").style.display = "none";
+        }
+      });
+      // Hide all h2s globally (for metadata section)
+      document
+        .querySelectorAll("#entryView h2")
+        .forEach((h) => (h.style.display = "none"));
+      return;
+    }
+    $("title").style.display = "";
     sections.forEach((id) => {
       const el = $(id) || qs(`.${id}`);
-      if (el) el.style.display = "none";
-      // Hide section headings (h2) inside each section
+      if (el) el.style.display = "";
       if (el && el.querySelector && el.querySelector("h2")) {
-        el.querySelector("h2").style.display = "none";
+        el.querySelector("h2").style.display = "";
       }
     });
-    // Hide all h2s globally (for metadata section)
     document
       .querySelectorAll("#entryView h2")
-      .forEach((h) => (h.style.display = "none"));
-    return;
-  }
-  $("title").style.display = "";
-  sections.forEach((id) => {
-    const el = $(id) || qs(`.${id}`);
-    if (el) el.style.display = "";
-    if (el && el.querySelector && el.querySelector("h2")) {
-      el.querySelector("h2").style.display = "";
-    }
+      .forEach((h) => (h.style.display = ""));
+    // Load the entry using the appropriate base URL
+    fetch(`${baseUrl}/entries/${file}`)
+      .then((r) => r.json())
+      .then(render)
+      .catch(console.error);
   });
-  document
-    .querySelectorAll("#entryView h2")
-    .forEach((h) => (h.style.display = ""));
-  // Load the entry using the appropriate base URL
-  fetch(`${baseUrl}/entries/${file}`)
-    .then((r) => r.json())
-    .then(render)
-    .catch(console.error);
-});
+}
 
 // Render function
 function render(data) {
@@ -120,9 +122,9 @@ function render(data) {
     "programmaticVerification",
     "references",
     "meta-domain",
-    "meta-dataset",
     "meta-created",
     "meta-status",
+    "metadata",
   ].forEach((id) => {
     const el = $(id) || qs(`.${id}`);
     if (el) el.style.display = "";
@@ -198,7 +200,6 @@ function render(data) {
   MathJax.typesetPromise([qs("#references")]);
 
   $("meta-domain").textContent = data.domain;
-  $("meta-dataset").textContent = data.dataset_version;
   $("meta-created").textContent = data.created_by;
   $("meta-status").textContent = data.review_status;
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -190,3 +190,62 @@ select option {
   background-color: #222;
   color: #fff;
 }
+
+/* Metadata footer styles */
+.entry-footer {
+  margin-top: 1.2rem;
+  padding: 0.6rem 1.2rem;
+  background: #f5f5f7; /* light mode default */
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  max-width: 520px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.latex-dark .entry-footer {
+  background: #2c2c2c;
+  border: 1px solid #444;
+}
+
+.metadata-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem 2.2rem;
+  justify-content: flex-start;
+  align-items: flex-start;
+}
+
+.metadata-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 120px;
+}
+
+.metadata-item strong {
+  color: var(--primary);
+  font-size: 1em;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.metadata-item span {
+  font-size: 0.97em;
+  color: #555;
+}
+
+.latex-dark .metadata-item span {
+  color: #b0b0b0;
+}
+
+@media (max-width: 600px) {
+  .metadata-grid {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .entry-footer {
+    padding: 0.5rem 0.7rem;
+  }
+}

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -185,3 +185,8 @@ select option {
   color: white;
   background-color: #333;
 }
+
+.latex-dark select {
+  background-color: #222;
+  color: #fff;
+}

--- a/entries/lorentz_transformations.json
+++ b/entries/lorentz_transformations.json
@@ -230,7 +230,6 @@
       "citation": "Taylor, E. F., & Wheeler, J. A. (1992). Spacetime Physics. W. H. Freeman and Company."
     }
   ],
-  "dataset_version": "0.0.1",
   "created_by": "Manuel Sánchez Hernández",
   "review_status": "reviewed"
 }

--- a/entries/maxwell_equations.json
+++ b/entries/maxwell_equations.json
@@ -259,8 +259,6 @@
       "citation": "Griffiths, D. J. (2013). *Introduction to Electrodynamics* (4th ed.). Pearson."
     }
   ],
-
-  "dataset_version": "0.1.0",
   "created_by": "Manuel Sánchez Hernández",
   "review_status": "draft"
 }

--- a/entries/schroedingen_equation.json
+++ b/entries/schroedingen_equation.json
@@ -144,7 +144,6 @@
       "citation": "Griffiths, D. J. (2018). *Introduction to Quantum Mechanics* (3rd ed.). Cambridge University Press."
     }
   ],
-  "dataset_version": "0.0.1",
   "created_by": "Manuel Sánchez Hernández",
   "review_status": "draft"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -54,7 +54,10 @@
     {
       "version": "0.2.5",
       "date": "2025-05-11",
-      "changes": ["Removed dataset version from entries"]
+      "changes": [
+        "Removed dataset version from entries",
+        "Added footer to each entry with licence in entries.html"
+      ]
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "dataset_name": "Theoretical Physics Inference Dataset",
-  "dataset_version": "0.2.4",
+  "dataset_version": "0.2.5",
   "description": "A curated dataset of self-contained theoretical physics derivations, equations, and explanations, designed for training and evaluating ML models.",
-  "created_at": "2025-04-14",
+  "originally_published_at": "2025-04-14",
   "license": "CC-BY 4.0",
   "domains": [
     "astro-ph",
@@ -34,8 +34,7 @@
         "Fixed the previous entries",
         "Updated README.md and CONTRIBUTING.md files with new contribution guidelines.",
         "Change schema to accept dots for the `domain` field.",
-        "Changing achronym from THEORIA to TheorIA",
-        "Updated dataset_version to 0.2.2"
+        "Changing achronym from THEORIA to TheorIA"
       ]
     },
     {
@@ -51,6 +50,11 @@
         "Sepparating index.html and entries.html",
         "Reordering entries.html"
       ]
+    },
+    {
+      "version": "0.2.5",
+      "date": "2025-05-11",
+      "changes": ["Removed dataset version from entries"]
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "dataset_name": "Theoretical Physics Inference Dataset",
-  "dataset_version": "0.2.0",
+  "dataset_version": "0.2.4",
   "description": "A curated dataset of self-contained theoretical physics derivations, equations, and explanations, designed for training and evaluating ML models.",
   "created_at": "2025-04-14",
   "license": "CC-BY 4.0",
@@ -25,7 +25,7 @@
     },
     {
       "version": "0.2.2",
-      "date": "2025-05-01",
+      "date": "2025-04-26",
       "changes": [
         "Added new entries for Lorentz transformations and Maxwell equations.",
         "Added index.html for better navigation.",
@@ -33,7 +33,23 @@
         "Updated references and citations.",
         "Fixed the previous entries",
         "Updated README.md and CONTRIBUTING.md files with new contribution guidelines.",
-        "Change schema to accept dots for the `domain` field."
+        "Change schema to accept dots for the `domain` field.",
+        "Changing achronym from THEORIA to TheorIA",
+        "Updated dataset_version to 0.2.2"
+      ]
+    },
+    {
+      "version": "0.2.3",
+      "date": "2025-04-27",
+      "changes": ["Changing achronym from THEORIA to TheorIA"]
+    },
+    {
+      "version": "0.2.4",
+      "date": "2025-05-06",
+      "changes": [
+        "Changing achronym from THEORIA to TheorIA",
+        "Sepparating index.html and entries.html",
+        "Reordering entries.html"
       ]
     }
   ]

--- a/schemas/entry.schema.json
+++ b/schemas/entry.schema.json
@@ -18,7 +18,6 @@
     "programmatic_verification",
     "domain",
     "references",
-    "dataset_version",
     "created_by",
     "review_status"
   ],
@@ -173,11 +172,6 @@
           "citation": { "type": "string" }
         }
       }
-    },
-
-    "dataset_version": {
-      "type": "string",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
     },
 
     "created_by": {


### PR DESCRIPTION
## Changelog

### v0.2.2 (2025-04-26)
- Added new entries for Lorentz transformations and Maxwell equations.
- Introduced `index.html` for improved navigation.
- Enhanced schema validation for equations and assumptions.
- Updated references and citations.
- Fixed issues in previous entries.
- Updated `README.md` and `CONTRIBUTING.md` with new contribution guidelines.
- Modified schema to accept dots in the `domain` field.
- Changed acronym from THEORIA to TheorIA.

### v0.2.3 (2025-04-27)
- Changed acronym from THEORIA to TheorIA.

### v0.2.4 (2025-05-06)
- Changed acronym from THEORIA to TheorIA.
- Separated `index.html` and `entries.html`.
- Reordered sections in `entries.html`.

### v0.2.5 (2025-05-11)
- Removed dataset version from entries.
- Added a footer to each entry in `entries.html` with license information.