### PR TITLE
Introduce entry dependencies and Planck law

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,18 @@ The following fields are required in each entry JSON file. Ensure that all entri
 ]
 ```
 
+- **`dependencies`:**
+  - Optional list of other entry filenames that this result relies on.
+  - Use the `.json` filenames exactly as listed in `docs/index.json`.
+  - Example:
+
+  ```json
+  "dependencies": [
+    "dirac_equation_free.json",
+    "maxwell_equations.json"
+  ]
+  ```
+
 - **`created_ by`:** Full name or ORCID of author of the entry.
 
 - **`review_status`:** Use "draft" for initial submissions. Final datasets published in main must be marked as "reviewed".

--- a/docs/entries.html
+++ b/docs/entries.html
@@ -154,6 +154,10 @@
         <h2>References</h2>
         <ul></ul>
       </section>
+      <section id="dependencies" style="display: none">
+        <h2>Dependencies</h2>
+        <ul></ul>
+      </section>
       <section class="metadata" style="display: none">
         <footer class="entry-footer">
           <div class="metadata-grid">

--- a/docs/index.json
+++ b/docs/index.json
@@ -12,6 +12,7 @@
   "maxwell_lorenz_gauge.json",
   "navier_stokes_incompressible.json",
   "noethers_theorem.json",
+  "planck_radiation_law.json",
   "qed_lagrangian.json",
   "schroedingen_equation.json",
   "stefan_boltzmann_law.json"

--- a/docs/script.js
+++ b/docs/script.js
@@ -51,6 +51,12 @@ if (window.location.pathname.includes("entries.html")) {
         o1.textContent = fn.replace(".json", "");
         $("entrySelector").appendChild(o1);
       });
+      const params = new URLSearchParams(window.location.search);
+      const initial = params.get("entry");
+      if (initial) {
+        $("entrySelector").value = initial;
+        $("entrySelector").dispatchEvent(new Event("change"));
+      }
     });
 
   // Handler for entry selector in entry view
@@ -64,6 +70,7 @@ if (window.location.pathname.includes("entries.html")) {
       "derivation",
       "programmaticVerification",
       "references",
+      "dependencies",
       "meta-domain",
       "meta-created",
       "meta-status",
@@ -121,6 +128,7 @@ function render(data) {
     "derivation",
     "programmaticVerification",
     "references",
+    "dependencies",
     "meta-domain",
     "meta-created",
     "meta-status",
@@ -201,6 +209,14 @@ function render(data) {
   renderList("#references ul", data.references, (r) => r.citation);
   MathJax.typesetPromise([qs("#references")]);
 
+  renderList(
+    "#dependencies ul",
+    data.dependencies || [],
+    (d) => `<a href="entries.html?entry=${d}">${d.replace(/\.json$/, "")}</a>`,
+    true
+  );
+  MathJax.typesetPromise([qs("#dependencies")]);
+
   $("meta-domain").textContent = data.domain;
   $("meta-created").textContent = data.created_by;
   $("meta-status").textContent = data.review_status;
@@ -232,12 +248,16 @@ function render(data) {
   MathJax.typesetPromise([qs("#entryView")]);
 }
 
-function renderList(sel, arr, fn) {
+function renderList(sel, arr, fn, rawHtml = false) {
   const el = qs(sel);
   if (!el) return;
   el.innerHTML = "";
   arr.forEach((item) => {
     const text = fn(item);
+    if (rawHtml) {
+      el.insertAdjacentHTML("beforeend", `<li>${text}</li>`);
+      return;
+    }
     const wrappedText = text.replace(/`([^`]+)`/g, (match, expr) => {
       // Replace hbar token with unicode ℏ for correct rendering
       const exprFixed = expr.replace(/\bhbar\b/g, "ℏ");

--- a/entries/bernoulli_equation.json
+++ b/entries/bernoulli_equation.json
@@ -106,6 +106,7 @@
       "citation": "Bernoulli, D. (1738). *Hydrodynamica*. Basel."
     }
   ],
+  "dependencies": ["navier_stokes_incompressible.json"],
   "created_by": "Synthetic entry, created with AI, may have mistakes. Looking for contributors to review all fields",
   "review_status": "draft"
 }

--- a/entries/dirac_equation_em.json
+++ b/entries/dirac_equation_em.json
@@ -199,6 +199,7 @@
       "citation": "Peskin, M. E., & Schroeder, D. V. (1995). *An Introduction to Quantum Field Theory*. Addison-Wesley."
     }
   ],
+  "dependencies": ["dirac_equation_free.json", "maxwell_equations.json"],
   "created_by": "Synthetic entry, created with AI, may have mistakes. Looking for contributors to review all fields",
   "review_status": "draft"
 }

--- a/entries/dirac_equation_free.json
+++ b/entries/dirac_equation_free.json
@@ -185,6 +185,7 @@
       "citation": "Peskin, M. E., & Schroeder, D. V. (1995). *An Introduction to Quantum Field Theory*. Addison-Wesley."
     }
   ],
+  "dependencies": ["klein_gordon_equation.json"],
   "created_by": "Synthetic entry, created with AI, may have mistakes. Looking for contributors to review all fields",
   "review_status": "draft"
 }

--- a/entries/fourier_heat_conduction.json
+++ b/entries/fourier_heat_conduction.json
@@ -92,6 +92,7 @@
       "citation": "Bergman, T. L., Lavine, A. S., Incropera, F. P., & DeWitt, D. P. (2011). *Introduction to Heat Transfer* (6th ed.). Wiley."
     }
   ],
+  "dependencies": ["first_law_thermodynamics.json"],
   "created_by": "Synthetic entry, created with AI, may have mistakes. Looking for contributors to review all fields",
   "review_status": "draft"
 }

--- a/entries/mass_energy_equivalence.json
+++ b/entries/mass_energy_equivalence.json
@@ -192,6 +192,7 @@
       "citation": "Kleppner, D., & Kolenkow, R. J. (2014). *An Introduction to Mechanics* (2nd ed.). Cambridge University Press. (Chapter 13 provides a derivation of relativistic energy)."
     }
   ],
+  "dependencies": ["lorentz_transformations.json"],
   "created_by": "Synthetic entry, created with AI, may have mistakes. Looking for contributors to review all fields",
   "review_status": "draft"
 }

--- a/entries/maxwell_lorenz_gauge.json
+++ b/entries/maxwell_lorenz_gauge.json
@@ -172,6 +172,7 @@
       "citation": "Lorenz, L. (1867). 'Über die Identität der Schwingungen des Lichts mit den elektrischen Strömen.' *Annalen der Physik und Chemie*, 131(10), 243–263."
     }
   ],
+  "dependencies": ["maxwell_equations.json"],
   "created_by": "Synthetic entry, created with AI, may have mistakes. Looking for contributors to review all fields",
   "review_status": "draft"
 }

--- a/entries/planck_radiation_law.json
+++ b/entries/planck_radiation_law.json
@@ -1,0 +1,53 @@
+{
+  "result_name": "Planck's Radiation Law",
+  "result_equations": [
+    {"id": "eq1", "equation": "u(nu,T) = (8*pi*h*nu^3)/(c^3*(exp(h*nu/(k*T)) - 1))"}
+  ],
+  "explanation": "Planck's law describes the spectral energy density of black-body radiation as a function of frequency and temperature. By quantizing electromagnetic modes with energy quanta `h*nu`, it resolves the ultraviolet catastrophe of classical physics and underpins modern quantum theory and thermal emission models.",
+  "equations_assumptions": [
+    {"id": "eq_assump1", "text": "Emitter is an ideal black body in thermal equilibrium."},
+    {"id": "eq_assump2", "text": "Radiation is isotropic and contained in a cavity of volume V."}
+  ],
+  "definitions": [
+    {"symbol": "u(nu,T)", "definition": "Spectral energy density per unit frequency."},
+    {"symbol": "nu", "definition": "Radiation frequency."},
+    {"symbol": "T", "definition": "Absolute temperature."},
+    {"symbol": "h", "definition": "Planck constant."},
+    {"symbol": "c", "definition": "Speed of light in vacuum."},
+    {"symbol": "k", "definition": "Boltzmann constant."}
+  ],
+  "derivation": [
+    {"step": 1, "equation": "rho(nu) = (8*pi*nu^2)/(c^3)"},
+    {"step": 2, "equation": "E_n = n*h*nu"},
+    {"step": 3, "equation": "<E> = (h*nu)/(exp(h*nu/(k*T)) - 1)"},
+    {"step": 4, "equation": "u(nu,T) = rho(nu)*<E>"}
+  ],
+  "derivation_assumptions": [
+    {"id": "ass1", "text": "Photon occupation numbers follow the Bose-Einstein distribution."},
+    {"id": "ass2", "text": "Energy levels of each mode are integer multiples of `h*nu`."}
+  ],
+  "derivation_explanation": [
+    {"step": 1, "text": "Count electromagnetic modes in a cavity between `nu` and `nu+dnu`."},
+    {"step": 2, "text": "Assume quantized energies with spacing `h*nu` for each mode."},
+    {"step": 3, "text": "Compute the thermal average energy per mode using Bose statistics."},
+    {"step": 4, "text": "Multiply density of states by average energy to obtain the spectral energy density."}
+  ],
+  "programmatic_verification": {
+    "language": "python 3.11.12",
+    "library": "sympy 1.12.0",
+    "code": [
+      "import sympy as sp",
+      "nu, T, h, k, c = sp.symbols('nu T h k c', positive=True)",
+      "u = (8*sp.pi*h*nu**3)/(c**3*(sp.exp(h*nu/(k*T)) - 1))",
+      "rho = (8*sp.pi*nu**2)/(c**3)",
+      "E_avg = (h*nu)/(sp.exp(h*nu/(k*T)) - 1)",
+      "assert sp.simplify(rho*E_avg - u) == 0"
+    ]
+  },
+  "domain": "astro-ph",
+  "references": [
+    {"id": "R1", "citation": "Planck, M. (1901). *On the Law of Distribution of Energy in the Normal Spectrum*. Annalen der Physik, 309(3), 553-563."}
+  ],
+  "created_by": "Synthetic entry, created with AI, may have mistakes. Looking for contributors to review all fields",
+  "review_status": "draft"
+}

--- a/entries/qed_lagrangian.json
+++ b/entries/qed_lagrangian.json
@@ -214,6 +214,11 @@
       "citation": "Greiner, W., & Reinhardt, J. (1996). *Field Quantization*. Springer-Verlag."
     }
   ],
+  "dependencies": [
+    "dirac_equation_em.json",
+    "maxwell_equations.json",
+    "noethers_theorem.json"
+  ],
   "created_by": "Synthetic entry, created with AI, may have mistakes. Looking for contributors to review all fields",
   "review_status": "draft"
 }

--- a/entries/stefan_boltzmann_law.json
+++ b/entries/stefan_boltzmann_law.json
@@ -138,6 +138,7 @@
       "citation": "Boltzmann, L. (1884). *Ableitung des Stefan'schen Gesetzes…* Annalen der Physik, 22, 291–294."
     }
   ],
+  "dependencies": ["planck_radiation_law.json"],
   "created_by": "Synthetic entry, created with AI, may have mistakes. Looking for contributors to review all fields",
   "review_status": "draft"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "dataset_name": "Theoretical Physics Inference Dataset",
-  "dataset_version": "0.2.5",
+  "dataset_version": "0.3.1",
   "description": "A curated dataset of self-contained theoretical physics derivations, equations, and explanations, designed for training and evaluating ML models.",
   "originally_published_at": "2025-04-14",
   "license": "CC-BY 4.0",
@@ -68,6 +68,15 @@
       "changes": [
         "Adding 14 new entries in draft mode",
         "Added .gitignore file with common patterns for development"
+      ]
+    },
+    {
+      "version": "0.3.1",
+      "date": "2025-05-20",
+      "changes": [
+        "Introduced optional dependencies field to entries",
+        "Added Planck's radiation law entry",
+        "Updated docs and schema to display entry dependencies"
       ]
     }
   ]

--- a/schemas/entry.schema.json
+++ b/schemas/entry.schema.json
@@ -174,6 +174,12 @@
       }
     },
 
+    "dependencies": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^[a-z0-9_]+\\.json$" },
+      "description": "List of other entry files this result relies on"
+    },
+
     "created_by": {
       "type": "string"
     },


### PR DESCRIPTION
## Summary
- document new optional `dependencies` field in contribution guide
- support dependencies in entry schema
- show dependencies in docs and allow linking between entries
- add Planck radiation law example
- update various entries with their dependencies
- bump dataset version to 0.3.1

## Testing
- `Testing not implemented due to missing jsonschema`